### PR TITLE
chore: bump artifact version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/configure-pages@v1
 
       - name: Download documents
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifacts/
 


### PR DESCRIPTION
Ahh, only download was v2, that's not it.